### PR TITLE
refactor: use new template location

### DIFF
--- a/js/geonovum/conformance.js
+++ b/js/geonovum/conformance.js
@@ -3,7 +3,7 @@
 // Handle the conformance section properly.
 
 define(
-    ["w3c/templates/compiled", "core/pubsubhub"],
+    ["templates", "core/pubsubhub"],
     function (tmpls, pubsubhub) {
         var confoTmpl = tmpls["conformance.html"];
         return {

--- a/js/geonovum/headers.js
+++ b/js/geonovum/headers.js
@@ -98,7 +98,7 @@ define(
         "handlebars.runtime"
     ,   "core/utils"
     ,   "core/pubsubhub"
-    ,   "geonovum/templates/compiled"
+    ,   "templates"
     ],
     function (hb, utils, pubsubhub, tmpls) {
         var cgbgHeadersTmpl = tmpls["cgbg-headers.html"];

--- a/js/geonovum/permalinks.js
+++ b/js/geonovum/permalinks.js
@@ -17,7 +17,7 @@
 //                         hovered over.  Defaults to false.
 
 define(
-    ["w3c/templates/compiled", "core/utils"], // load this to be sure that the jQuery extensions are loaded
+    ["templates", "core/utils"], // load this to be sure that the jQuery extensions are loaded
     function (tmpls, utils) {
         const css = tmpls["permalinks.css"]; 
         return {


### PR DESCRIPTION
I generalized template bundling so it just all ends up in `js/templates`.  

@lvdbrink, please note that the generated file is not committed to github (on purpose, as it will be different from mine). 

To generate it locally, just run:

```
npm run hb:build
```

That gets automatically run also when you do a generic build:

```
npm run build
```
